### PR TITLE
Reduce default index interval size

### DIFF
--- a/taf_index.c
+++ b/taf_index.c
@@ -13,7 +13,7 @@ static void usage() {
     fprintf(stderr, "taf_index [options]\n");
     fprintf(stderr, "Index a TAF file, output goes in <file>.tai\n");
     fprintf(stderr, "-i --inputFile : Input taf file to invert [REQUIRED]\n");
-    fprintf(stderr, "-b --blockSize : Write an index line for intervals of this many bp [default:1000000]\n");
+    fprintf(stderr, "-b --blockSize : Write an index line for intervals of this many bp [default:10000]\n");
     fprintf(stderr, "-l --logLevel : Set the log level\n");
     fprintf(stderr, "-h --help : Print this help message\n");
 }
@@ -26,7 +26,7 @@ int taf_index_main(int argc, char *argv[]) {
      */
     char *logLevelString = NULL;
     char *taf_fn = NULL;
-    int64_t block_size = 1000000;
+    int64_t block_size = 10000;
 
     ///////////////////////////////////////////////////////////////////////////
     // Parse the inputs


### PR DESCRIPTION
From 100kb to 10kb.  

I ran a test to pull 4552 conserved elements from a 447-way alignment on EBS (these results will surely vary quite a bit with different disk speeds).  These are stats for the wall times of the 4552 calls to `taffy view`
```
interval               min(s)  max(s)   mean(s)  .tai size(b)
10000                  0.32    1.37     0.557465   6,063,872
10000(gzipped)         0.35    1.40     0.58652    2,354,266
50000                  0.06    4.11     1.07682    1,269,988
100000                 0.03    8.85     2.13459    668,210
```

The 10kb has what looks like a 0.3s loading time plus a worst-case scanning time of 1s.  As expected, longer intervals decrease the former at the expense of the latter.  Zipping the index didn't really change much but was slightly slower. 

I'll try smaller indexes (and also need to switch from length to bytes for determining index intervals).  But the returns will probably be diminishing from this point on (it's hard to imagine mean time coming down much further if at all).

All said, looking at these I'm pretty confident in the current index's ability to be a decent browser backend.  Would really be interesting to see the same test done on bigmaf.  

