### PR TITLE
Add taffy stats command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,8 @@ ${srcDir}/tai.o : ${srcDir}/tai.c ${libHeaders}
 ${BINDIR}/stTafTests : ${libTests} ${LIBDIR}/libstTaf.a ${stTafDependencies}
 	${CC} ${CFLAGS} ${LDFLAGS} -o ${BINDIR}/stTafTests ${libTests} ${LIBDIR}/libstTaf.a ${LDLIBS}
 
-${BINDIR}/taffy : taf_norm.o taf_add_gap_bases.o taf_index.o taf_view.o taffy_main.o ${LIBDIR}/libstTaf.a ${libHeaders} ${stTafDependencies}
-	${CXX} ${CPPFLAGS} ${CXXFLAGS} taf_norm.o taf_add_gap_bases.o taf_index.o taf_view.o taffy_main.o -o ${BINDIR}/taffy ${LIBDIR}/libstTaf.a ${LDLIBS}
+${BINDIR}/taffy : taf_norm.o taf_add_gap_bases.o taf_index.o taf_view.o taf_stats.o taffy_main.o ${LIBDIR}/libstTaf.a ${libHeaders} ${stTafDependencies}
+	${CXX} ${CPPFLAGS} ${CXXFLAGS} taf_norm.o taf_add_gap_bases.o taf_index.o taf_view.o taf_stats.o taffy_main.o -o ${BINDIR}/taffy ${LIBDIR}/libstTaf.a ${LDLIBS}
 
 taffy_main.o : taffy_main.cpp ${stTafDependencies} ${libHeaders}
 	${CXX} ${CPPFLAGS} ${CXXFLAGS} -o taffy_main.o -c taffy_main.cpp
@@ -69,6 +69,9 @@ taf_index.o : taf_index.c ${stTafDependencies} ${libHeaders}
 
 taf_view.o : taf_view.c ${stTafDependencies} ${libHeaders}
 	${CC} ${CFLAGS} ${CFLAGS} -o taf_view.o -c taf_view.c
+
+taf_stats.o : taf_stats.c ${stTafDependencies} ${libHeaders}
+	${CC} ${CFLAGS} ${CFLAGS} -o taf_stats.o -c taf_stats.c
 
 test : all ${BINDIR}/stTafTests
 	${BINDIR}/stTafTests

--- a/taf_add_gap_bases.cpp
+++ b/taf_add_gap_bases.cpp
@@ -302,7 +302,7 @@ int taf_add_gap_bases_main(int argc, char *argv[]) {
         stSet_destruct(hal_species);
     }
 
-    st_logInfo("taf_add_gap_bases is done, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
+    st_logInfo("taffy add-gap-bases is done, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
 
     //while(1);
     //assert(0);

--- a/taf_index.c
+++ b/taf_index.c
@@ -110,7 +110,7 @@ int taf_index_main(int argc, char *argv[]) {
 
     LI_destruct(li);
     
-    st_logInfo("taf_index is done, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
+    st_logInfo("taffy index is done, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
 
     return 0;
 }

--- a/taf_norm.c
+++ b/taf_norm.c
@@ -197,7 +197,7 @@ int taf_norm_main(int argc, char *argv[]) {
         fclose(output);
     }
 
-    st_logInfo("taf_norm is done, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
+    st_logInfo("taffy norm is done, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
 
     //while(1);
     //assert(0);

--- a/taf_stats.c
+++ b/taf_stats.c
@@ -1,0 +1,149 @@
+/*
+ * taf view: MAF/TAF conversion and subregion extraction
+ *
+ *  Released under the MIT license, see LICENSE.txt
+*/
+
+#include "taf.h"
+#include "tai.h"
+#include "sonLib.h"
+#include <getopt.h>
+#include <time.h>
+
+static void usage() {
+    fprintf(stderr, "taf stats [options]\n");
+    fprintf(stderr, "Print statitstics from a TAF file\n");
+    fprintf(stderr, "-i --inputFile : Input TAF file. If not specified reads from stdin\n");
+    fprintf(stderr, "-s --sequenceLengths : Print length of each *reference* sequence in the (indexed TAF) alignment\n");
+    fprintf(stderr, "-l --logLevel : Set the log level\n");
+    fprintf(stderr, "-h --help : Print this help message\n");
+}
+
+int taf_stats_main(int argc, char *argv[]) {
+    time_t startTime = time(NULL);
+
+    /*
+     * Arguments/options
+     */
+    char *logLevelString = NULL;
+    char *taf_fn = NULL;
+    bool seq_lengths = false;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Parse the inputs
+    ///////////////////////////////////////////////////////////////////////////
+
+    while (1) {
+        static struct option long_options[] = { { "logLevel", required_argument, 0, 'l' },
+                                                { "inputFile", required_argument, 0, 'i' },
+                                                { "sequenceLengths", no_argument, 0, 's' },
+                                                { "help", no_argument, 0, 'h' },
+                                                { 0, 0, 0, 0 } };
+
+        int option_index = 0;
+        int64_t key = getopt_long(argc, argv, "l:i:sh", long_options, &option_index);
+        if (key == -1) {
+            break;
+        }
+
+        switch (key) {
+            case 'l':
+                logLevelString = optarg;
+                break;
+            case 'i':
+                taf_fn = optarg;
+                break;
+            case 's':
+                seq_lengths = 1;
+                break;
+            case 'h':
+                usage();
+                return 0;
+            default:
+                usage();
+                return 1;
+        }
+    }
+    
+    //////////////////////////////////////////////
+    //Log the inputs
+    //////////////////////////////////////////////
+
+    st_setLogLevelFromString(logLevelString);
+    st_logInfo("Input file string : %s\n", taf_fn);
+
+    //////////////////////////////////////////////
+    // Do the stats
+    //////////////////////////////////////////////
+
+    if (seq_lengths == false) {
+        fprintf(stderr, "Please pick a stats option from { -s }\n");
+        return 1;
+    }
+    
+    // load the input
+    FILE *taf_fh = taf_fn == NULL ? stdin : fopen(taf_fn, "r");
+    if (taf_fh == NULL) {
+        fprintf(stderr, "Unable to open input TAF file: %s\n", taf_fn);
+        return 1;
+    }
+    LI *li = LI_construct(taf_fh);
+    
+    // sniff the format
+    int input_format = check_input_format(LI_peek_at_next_line(li));
+    if (input_format == 2) {
+        fprintf(stderr, "Input not supported: unable to detect ##maf or #taf header\n");
+        return 1;
+    }
+    if (input_format == 1) {
+        fprintf(stderr, "taffy stats does not (yet) support maf input\n");
+        return 1;
+    }
+
+    // load the index if it's required by the given options
+    bool index_required = seq_lengths;
+    char *tai_fn = NULL;
+    FILE *tai_fh = NULL;
+    Tai *tai = NULL;
+    if (index_required) {
+        tai_fn = tai_path(taf_fn);
+        tai_fh = fopen(tai_fn, "r");
+        if (tai_fh == NULL) {
+            fprintf(stderr, "Required index %s not found. Please run taffy index first\n", tai_fn);
+            return 1;
+        }
+        tai = tai_load(tai_fh);
+    }
+
+    // do the stats
+    if (seq_lengths) {
+        stHash *seq_to_len = tai_sequence_lengths(tai, li);
+        stList *seq_names = stHash_getKeys(seq_to_len);
+        for (int64_t i = 0; i < stList_length(seq_names); ++i) {
+            void *hash_val = stHash_search(seq_to_len, stList_get(seq_names, i));
+            fprintf(stdout, "%s\t%" PRIi64 "\n", (char*)stList_get(seq_names, i), (int64_t)hash_val);
+        }
+        stHash_destruct(seq_to_len);
+        stList_destruct(seq_names);
+    }
+
+        
+    //////////////////////////////////////////////
+    // Cleanup
+    //////////////////////////////////////////////
+
+    if (index_required) {
+        free(tai_fn);
+        tai_destruct(tai);
+    }
+    
+    LI_destruct(li);
+    if(taf_fn != NULL) {
+        fclose(taf_fh);
+    }
+
+    st_logInfo("taffy stats is done, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
+
+    return 0;
+}
+

--- a/taf_view.c
+++ b/taf_view.c
@@ -25,25 +25,6 @@ static void usage() {
     fprintf(stderr, "-h --help : Print this help message\n");
 }
 
-// sniff format
-// 0: taf
-// 1: maf
-// 2: unknown
-static int check_input_format(const char *line) {
-    int ret = 2;
-    assert(line != NULL);
-    stList *tokens = stString_split(line);
-    if (stList_length(tokens) > 0) {
-        if (strcmp(stList_get(tokens, 0), "#taf") == 0) {
-            ret = 0;
-        } else if (strcmp(stList_get(tokens, 0), "##maf") == 0) {
-            ret = 1;
-        }
-    }            
-    stList_destruct(tokens);
-    return ret;
-}
-
 int taf_view_main(int argc, char *argv[]) {
     time_t startTime = time(NULL);
 
@@ -122,7 +103,16 @@ int taf_view_main(int argc, char *argv[]) {
     //////////////////////////////////////////////
 
     FILE *input = inputFile == NULL ? stdin : fopen(inputFile, "r");
+    if (input == NULL) {
+        fprintf(stderr, "Unable to open input file: %s\n", inputFile);
+        return 1;
+    }
+
     FILE *output = outputFile == NULL ? stdout : fopen(outputFile, "w");
+    if (output == NULL) {
+        fprintf(stderr, "Unable to open output file: %s\n", outputFile);
+        return 1;
+    }
     LI *li = LI_construct(input);
 
     // sniff the format
@@ -264,7 +254,7 @@ int taf_view_main(int argc, char *argv[]) {
         fclose(output);
     }
 
-    st_logInfo("taf view is done, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
+    st_logInfo("taffy view is done, %" PRIi64 " seconds have elapsed\n", time(NULL) - startTime);
 
     return 0;
 }

--- a/taffy/impl/taf.c
+++ b/taffy/impl/taf.c
@@ -398,3 +398,18 @@ void taf_write_block(Alignment *p_alignment, Alignment *alignment, bool run_leng
 void taf_write_header(Tag *tag, FILE *fh) {
     write_header(tag, fh, "#taf", ":", "\n");
 }
+
+int check_input_format(const char *header_line) {
+    int ret = 2;
+    assert(header_line != NULL);
+    stList *tokens = stString_split(header_line);
+    if (stList_length(tokens) > 0) {
+        if (strcmp(stList_get(tokens, 0), "#taf") == 0) {
+            ret = 0;
+        } else if (strcmp(stList_get(tokens, 0), "##maf") == 0) {
+            ret = 1;
+        }
+    }            
+    stList_destruct(tokens);
+    return ret;
+}

--- a/taffy/inc/taf.h
+++ b/taffy/inc/taf.h
@@ -188,5 +188,14 @@ bool has_coordinates(stList *tokens, int64_t *j);
 char *parse_coordinates(int64_t *j, stList *tokens, int64_t *start, bool *strand,
                         int64_t *sequence_length);
 
+/**
+ * Sniff file format from header line.  returns:
+ *  0: taf
+ *  1: maf
+ *  2: unknown
+ */
+int check_input_format(const char *header_line);
+
+
 #endif /* STTAF_H_ */
 

--- a/taffy/inc/tai.h
+++ b/taffy/inc/tai.h
@@ -74,4 +74,9 @@ Alignment *tai_next(TaiIt *tai_it, LI *li);
  */
 void tai_iterator_destruct(TaiIt *tai_it);
 
+/**
+ * Return a map of Sequence name to Length. Only reference (ie indexed) sequences are returned
+ */
+stHash *tai_sequence_lengths(Tai *idx, LI *li);
+
 #endif

--- a/taffy_main.cpp
+++ b/taffy_main.cpp
@@ -9,6 +9,7 @@ extern "C" {
 extern int taf_norm_main(int argc, char *argv[]);
 extern int taf_index_main(int argc, char *argv[]);
 extern int taf_view_main(int argc, char *argv[]);
+extern int taf_stats_main(int argc, char *argv[]);
 }
 
 extern int taf_add_gap_bases_main(int argc, char *argv[]);
@@ -20,7 +21,9 @@ void usage() {
     fprintf(stderr, "    view           MAF / TAF conversion and region extraction\n");
     fprintf(stderr, "    norm           normalize TAF blocks\n");
     fprintf(stderr, "    add-gap-bases  add sequences from HAL or FASTA files into TAF gaps\n");
-    fprintf(stderr, "    index          create a .tai index (required for region extraction)\n\n");
+    fprintf(stderr, "    index          create a .tai index (required for region extraction)\n");
+    fprintf(stderr, "    stats          print statistics of a TAF file\n");
+    fprintf(stderr, "\n");
 
 #ifdef USE_HTSLIB
     fprintf(stderr, "all commands accept uncompressed or bgzipped TAF input\n");
@@ -44,6 +47,8 @@ int main(int argc, char *argv[]) {
         return taf_add_gap_bases_main(argc - 1, argv + 1);
     } else if (strcmp(argv[1], "index") == 0) {
         return taf_index_main(argc - 1, argv + 1);
+    } else if (strcmp(argv[1], "stats") == 0) {
+        return taf_stats_main(argc - 1, argv + 1);
     } else {
         fprintf(stderr, "%s is not a valid taffy command\n", argv[1]);
         usage();

--- a/tests/tai/test_tai.py
+++ b/tests/tai/test_tai.py
@@ -49,6 +49,21 @@ def create_index(taf_path, block_size):
 
     subprocess.check_call(['./bin/taffy', 'index', '-i', taf_path, '-b', str(block_size)])
     assert os.path.isfile(taf_path + '.tai')
+
+def check_anc0_stats(stats_string):
+    true_string = '''Anc0.Anc0refChr0	4151
+Anc0.Anc0refChr10	14504
+Anc0.Anc0refChr11	38002
+Anc0.Anc0refChr1	3407
+Anc0.Anc0refChr2	269145
+Anc0.Anc0refChr3	165
+Anc0.Anc0refChr4	13557
+Anc0.Anc0refChr5	50896
+Anc0.Anc0refChr6	22717
+Anc0.Anc0refChr7	1851
+Anc0.Anc0refChr8	111467
+Anc0.Anc0refChr9	4824'''
+    assert(stats_string.strip() == true_string)
     
 def test_tai(regions_path, taf_path, bgzip, block_size):
     sys.stderr.write(" * running indexing/extraction tests on {} with bzgip={} and blocksize={}".format(taf_path, bgzip, block_size))
@@ -63,6 +78,9 @@ def test_tai(regions_path, taf_path, bgzip, block_size):
         for line in regions_file:
             contig, start, end = line.split()[:3]
             test_region(taf_path, contig, start, end)
+
+    seq_stats = subprocess.check_output('taffy stats -s -i {} | sort -k1'.format(taf_path), shell=True).decode('utf-8')
+    check_anc0_stats(seq_stats)
 
     if bgzip:
         subprocess.check_call(['rm', '-f', taf_path])


### PR DESCRIPTION
Right now, all it does is print the (reference) sequence lengths using the TAF index.  

Would like to eventually add basic stuff like
* coverage
* block size

etc.  And I think a lot of this can be done (somewhat) quickly using the index by parallelizing across the file.  