### PR TITLE
Support MAF indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ For example, to normalize a maf file do the following:
 unaligned sequences between maf blocks and `taffy norm` then merges together the blocks. The 
 `-k` option causes the output to be in maf format.
 
-# Referenced-based TAF and Indexing
+# Referenced-based MAF/TAF and Indexing
 
 Neither format specification requires it, but *in practice* TAF, like MAF, is used to specify alignments
 along a single reference genome.  For instance, MAF files from both MultiZ and Cactus (via hal2maf)
@@ -229,9 +229,9 @@ sequence is specified on an anchor line, then the TAF file is **indexable**.
 
 A TAF file produced from a reference-based MAF file using `taf view` will be reference-based and indexable.
 
-Indexable TAF files can be indexed for random-access using `taffy index`:
+Indexable TAF files and reference-based MAF files can be indexed for random-access using `taffy index`:
 
-    taffy index -i TAF_FILE
+    taffy index -i TAF_FILE (or MAF_FILE)
 
 This command will create `TAF_FILE.tai`, which is a list mapping sequence names (first column) and
 start positions (second column) to offsets in the TAF file (third column). If two consecutive
@@ -241,16 +241,14 @@ lines (whose frequency is controlled by `taffy view -s` can ever be indexed.  Sm
 intervals will result in faster lookup times at the cost of the index itself being slower
 to load.
 
-Tuning this is a work in progress.
-
-An indexed TAF file can be accessed using `taffy view -r` to quickly pull out a subregion. For
+An indexed TAF or MAF file can be accessed using `taffy view -r` to quickly pull out a subregion. For
 example, `taffy view -r hg38.chr10:550000-600000` will extract the 50000bp (0-based, open-ended)
 interval on `hg38.chr10` in either TAF (default) or MAF (add `-m`) format. This works only if
-the TAF is referenced on hg38.
+the TAF/MAF is referenced on hg38.
 
 Notes:
 
-* The sequence names do not need to be ordered for TAF indexing (ie chr2 could come before chr1
+* The sequence names do not need to be ordered for TAF/MAF indexing (ie chr2 could come before chr1
 in the file). Just the positions within each sequence must be in order
 
 * The index could further be generalized to support out-of-order (but still non-overlapping!)

--- a/taf_index.c
+++ b/taf_index.c
@@ -1,5 +1,5 @@
 /*
- * taf_index: Make a .tai index from a TAF file (which can be bgzipped or uncompressed)
+ * taf_index: Make a .tai index from a TAF or MAF file (which can be bgzipped or uncompressed)
  *
  *  Released under the MIT license, see LICENSE.txt
 */
@@ -11,8 +11,8 @@
 
 static void usage() {
     fprintf(stderr, "taf_index [options]\n");
-    fprintf(stderr, "Index a TAF file, output goes in <file>.tai\n");
-    fprintf(stderr, "-i --inputFile : Input taf file to invert [REQUIRED]\n");
+    fprintf(stderr, "Index a TAF or MAF file, output goes in <file>.tai\n");
+    fprintf(stderr, "-i --inputFile : Input taf or maf file [REQUIRED]\n");
     fprintf(stderr, "-b --blockSize : Write an index line for intervals of this many bp [default:10000]\n");
     fprintf(stderr, "-l --logLevel : Set the log level\n");
     fprintf(stderr, "-h --help : Print this help message\n");
@@ -82,7 +82,7 @@ int taf_index_main(int argc, char *argv[]) {
     }
     FILE *taf_fh = fopen(taf_fn, "r");
     if (taf_fh == NULL) {
-        fprintf(stderr, "Unable to open input TAF file: %s\n", taf_fn);
+        fprintf(stderr, "Unable to open input file: %s\n", taf_fn);
         return 1;
     }
     char *tai_fn = tai_path(taf_fn);
@@ -90,7 +90,7 @@ int taf_index_main(int argc, char *argv[]) {
     FILE *tai_fh = fopen(tai_fn, "w");    
     LI *li = LI_construct(taf_fh);
     if (!LI_indexable(li)) {
-        fprintf(stderr, "Input TAF file must be either uncompressed or bgzipped: gzip not supported: %s\n", taf_fn);
+        fprintf(stderr, "Input file must be either uncompressed or bgzipped: gzip not supported: %s\n", taf_fn);
         return 1;
     }
 

--- a/taf_stats.c
+++ b/taf_stats.c
@@ -12,9 +12,9 @@
 
 static void usage() {
     fprintf(stderr, "taf stats [options]\n");
-    fprintf(stderr, "Print statitstics from a TAF file\n");
-    fprintf(stderr, "-i --inputFile : Input TAF file. If not specified reads from stdin\n");
-    fprintf(stderr, "-s --sequenceLengths : Print length of each *reference* sequence in the (indexed TAF) alignment\n");
+    fprintf(stderr, "Print statitstics from a TAF or MAF file\n");
+    fprintf(stderr, "-i --inputFile : Input TAF or MAF file. If not specified reads from stdin\n");
+    fprintf(stderr, "-s --sequenceLengths : Print length of each *reference* sequence in the (indexed) alignment\n");
     fprintf(stderr, "-l --logLevel : Set the log level\n");
     fprintf(stderr, "-h --help : Print this help message\n");
 }
@@ -95,10 +95,6 @@ int taf_stats_main(int argc, char *argv[]) {
         fprintf(stderr, "Input not supported: unable to detect ##maf or #taf header\n");
         return 1;
     }
-    if (input_format == 1) {
-        fprintf(stderr, "taffy stats does not (yet) support maf input\n");
-        return 1;
-    }
 
     // load the index if it's required by the given options
     bool index_required = seq_lengths;
@@ -112,7 +108,7 @@ int taf_stats_main(int argc, char *argv[]) {
             fprintf(stderr, "Required index %s not found. Please run taffy index first\n", tai_fn);
             return 1;
         }
-        tai = tai_load(tai_fh);
+        tai = tai_load(tai_fh, input_format == 1);
     }
 
     // do the stats

--- a/taffy/_taffy_build.py
+++ b/taffy/_taffy_build.py
@@ -193,7 +193,7 @@ ffibuilder.cdef("""
     /*
      * Load the index from disk
      */
-    Tai *tai_load(FILE* idx_fh);
+    Tai *tai_load(FILE* idx_fh, bool maf);
     
     /*
      * Free the index

--- a/taffy/inc/tai.h
+++ b/taffy/inc/tai.h
@@ -14,6 +14,7 @@
 typedef struct _Tai {
     stSortedSet *idx;
     stList *names; // just to keep track of memory -- we only keep one instance of each sequence name
+    bool maf;
 } Tai;
 
 typedef struct _TaiIt {
@@ -24,6 +25,7 @@ typedef struct _TaiIt {
     Alignment *alignment;
     Alignment *p_alignment;
     bool run_length_encode_bases;
+    bool maf;
 } TaiIt;
 
 
@@ -50,7 +52,7 @@ int tai_create(LI *li, FILE* idx_fh, int64_t index_block_size);
 /*
  * Load the index from disk
  */
-Tai *tai_load(FILE* idx_fh);
+Tai *tai_load(FILE* idx_fh, bool maf);
 
 /*
  * Free the index

--- a/taffy/lib.py
+++ b/taffy/lib.py
@@ -145,10 +145,10 @@ class Row:
 class TafIndex:
     """ Taf Index (.tai)
     """
-    def __init__(self, file, file_string_not_handle=True):
+    def __init__(self, file, is_maf, file_string_not_handle=True):
         """ Load from a file. Can be a file name or a Python file handle """
         c_file_handle = _get_c_file_handle(file, file_string_not_handle)
-        self._c_taf_index = lib.tai_load(c_file_handle)
+        self._c_taf_index = lib.tai_load(c_file_handle, is_maf)
         if file_string_not_handle:  # Close the underlying file handle if opened
             lib.fclose(c_file_handle)
 

--- a/tests/taffyTest.py
+++ b/tests/taffyTest.py
@@ -150,7 +150,7 @@ class TafTest(unittest.TestCase):
         write_taf_index_file(taf_file=self.test_taf_file, index_file=self.test_index_file)
 
         # Make the Taf Index object
-        taf_index = TafIndex(self.test_index_file)
+        taf_index = TafIndex(self.test_index_file, False)
 
         # Create a taf reader
         with AlignmentParser(self.test_taf_file,

--- a/tests/tai/test_tai.py
+++ b/tests/tai/test_tai.py
@@ -88,7 +88,9 @@ def test_tai(regions_path, taf_path, bgzip, block_size):
     sys.stderr.write("\t\t\tOK\n")    
     
 sys.stderr.write("Running tai tests...\n")
-maf_path = './tests/evolverMammals.maf'
+maf_path_in = './tests/evolverMammals.maf'
+maf_path = './tests/tai/evolverMammals.maf'
+subprocess.check_call(['cp', maf_path_in, maf_path])
 taf_path = './tests/tai/evolverMammals.taf'
 sys.stderr.write(" * creating evolver taf {}".format(taf_path))
 subprocess.check_call(['./bin/taffy', 'view', '-i', maf_path, '-o', taf_path])
@@ -103,5 +105,7 @@ test_tai(regions_path, taf_path, False, 111)
 test_tai(regions_path, taf_path, True, 200)
 test_tai(regions_path, taf_rle_path, False, 111)
 test_tai(regions_path, taf_rle_path, True, 200)
+test_tai(regions_path, maf_path, False, 111)
+test_tai(regions_path, maf_path, True, 200)
 
-subprocess.check_call(['rm', '-f', taf_path, taf_rle_path])
+subprocess.check_call(['rm', '-f', taf_path, taf_rle_path, maf_path])


### PR DESCRIPTION
Can now make a ".tai" index for MAF files too.  Works exactly as for TAF (though I haven't benchmarked much). Has the same requirement that input must be ordered along reference genome. 

Nice error messages on invalid (ie unsorted input) still a todo for both maf and taf. 

The interface should be completely transparent, except `tai_load()` now needs a flag telling whether it's maf or taf. 

`taf view` and `taf stats` can now be used in the exact same manner on either type of file.  