### PR TITLE
Better error msg when opening gzipped input without htslib

### DIFF
--- a/taffy/impl/taf.c
+++ b/taffy/impl/taf.c
@@ -411,5 +411,12 @@ int check_input_format(const char *header_line) {
         }
     }            
     stList_destruct(tokens);
+#ifndef USE_HTSLIB   
+    if (ret == 2 && strlen(header_line) >= 2 &&
+        (unsigned char)header_line[0] == 0x1f && (unsigned char)header_line[1] == 0x8b) {
+        fprintf(stderr, "(b)gzipped input support disabled: please build TAFFY with htslib\n");
+        exit(1);
+    }     
+#endif
     return ret;
 }


### PR DESCRIPTION
htslib is required to gzipped or bgzipped input.  But not having it leads to a generic error message about not being able to parse the header.  This fixes that by adding an explicit check for the case of gzipped input with no htslib support.  