### PR TITLE
Add support for on-the-fly genome renaming via input tsv to taffy view

### DIFF
--- a/taf_add_gap_bases.cpp
+++ b/taf_add_gap_bases.cpp
@@ -18,7 +18,7 @@ static int64_t maximum_gap_string_length = 50;
 static int64_t repeat_coordinates_every_n_columns = 1000;
 
 static void usage() {
-    fprintf(stderr, "taf_add_gap_bases SEQ_FILExN [options]\n");    
+    fprintf(stderr, "taffy add_gap_bases SEQ_FILExN [options]\n");    
     fprintf(stderr, "Add interstitial gap strings to taf file\n");
     fprintf(stderr, "-i --inputFile : Input taf file to normalize. If not specified reads from stdin\n");
     fprintf(stderr, "-o --outputFile : Output taf file. If not specified outputs to stdout\n");

--- a/taf_index.c
+++ b/taf_index.c
@@ -10,7 +10,7 @@
 #include <time.h>
 
 static void usage() {
-    fprintf(stderr, "taf_index [options]\n");
+    fprintf(stderr, "taffy index [options]\n");
     fprintf(stderr, "Index a TAF or MAF file, output goes in <file>.tai\n");
     fprintf(stderr, "-i --inputFile : Input taf or maf file [REQUIRED]\n");
     fprintf(stderr, "-b --blockSize : Write an index line for intervals of this many bp [default:10000]\n");

--- a/taf_norm.c
+++ b/taf_norm.c
@@ -15,7 +15,7 @@ float fraction_shared_rows = 0.6;
 int64_t repeat_coordinates_every_n_columns = 1000;
 
 static void usage() {
-    fprintf(stderr, "taf_norm [options]\n");
+    fprintf(stderr, "taffy norm [options]\n");
     fprintf(stderr, "Normalize a taf format alignment to remove small blocks using the -m and -n options to determine what to merge \n");
     fprintf(stderr, "-i --inputFile : Input taf file to normalize. If not specified reads from stdin\n");
     fprintf(stderr, "-o --outputFile : Output taf file. If not specified outputs to stdout\n");

--- a/taf_stats.c
+++ b/taf_stats.c
@@ -11,7 +11,7 @@
 #include <time.h>
 
 static void usage() {
-    fprintf(stderr, "taf stats [options]\n");
+    fprintf(stderr, "taffy stats [options]\n");
     fprintf(stderr, "Print statitstics from a TAF or MAF file\n");
     fprintf(stderr, "-i --inputFile : Input TAF or MAF file. If not specified reads from stdin\n");
     fprintf(stderr, "-s --sequenceLengths : Print length of each *reference* sequence in the (indexed) alignment\n");

--- a/taffy/inc/taf.h
+++ b/taffy/inc/taf.h
@@ -196,6 +196,32 @@ char *parse_coordinates(int64_t *j, stList *tokens, int64_t *start, bool *strand
  */
 int check_input_format(const char *header_line);
 
+/**
+ * Load a two-column genome name mapping file and return
+ * a hash table mapping COLUMN1 -> COLUMN2
+ */
+stHash *load_genome_name_mapping(char *name_mapping_path);
+
+/**
+ * Apply the name mapping to a string. If the string is found in the map,
+ * the mapped name is return.  Otherwise NULL is returned.
+ * If the input name has a "." in it, only the part before the "."
+ * is considered (following ucsc genome.contig convention).
+ *
+ * So if our mapping contaings hg19 -> Homo_sapiens, then
+ *
+ * apply_genome_name_mapping("hg19") would return "Homo_sapiens"
+ * and
+ * apply_genome_name_mapping("hg19.ch10") would return "Homo_sapiens.chr10"
+ *
+ * If a string is returned, it's up to the client to free it
+ */
+char *apply_genome_name_mapping(stHash *genome_name_map, char *input_name);
+
+/**
+ * Apply the name mapping to an alignment block.
+ */
+void apply_genome_name_mapping_to_alignment(stHash *genome_name_map, Alignment *alignment);
 
 #endif /* STTAF_H_ */
 

--- a/taffy/inc/taf.h
+++ b/taffy/inc/taf.h
@@ -197,6 +197,20 @@ char *parse_coordinates(int64_t *j, stList *tokens, int64_t *start, bool *strand
 int check_input_format(const char *header_line);
 
 /**
+ * it turns out just scanning for a "." doesn't work, even with the output of hal2maf.  The reason is
+ * that spcecies names can contain "." characters -- at least they do in the VGP alignment.
+ * so this function uses knowloedge of the genome names to greedily scan for a prefix ending in "."
+ * that corresponds to a genome name in the hal. the extracted genome name is returned if found
+ * (it must be freed)
+ *
+ * (note: this function was originally in taf_add_gap_bases.c where it took a set of species. It's
+ * now used by the renaming function int taf_view.c where it uses the hash.  Only one can
+ * be specified. If the hal set is used, it fails with an error if it can't find a key. If
+ * the hash is used, then it just returns NULL). 
+*/
+char *extract_genome_name(const char *sequence_name, stSet *hal_species, stHash *genome_name_map);
+
+/**
  * Load a two-column genome name mapping file and return
  * a hash table mapping COLUMN1 -> COLUMN2
  */
@@ -213,6 +227,10 @@ stHash *load_genome_name_mapping(char *name_mapping_path);
  * apply_genome_name_mapping("hg19") would return "Homo_sapiens"
  * and
  * apply_genome_name_mapping("hg19.ch10") would return "Homo_sapiens.chr10"
+ *
+ * If there's more than one dot, it will try splitting at each one so
+ *
+ * apply_genome_name_mapping("hg19.1.chr10") would return "Homo_sapiens.1.chr10"
  *
  * If a string is returned, it's up to the client to free it
  */

--- a/tests/tai/evolverMammals_ancestor_name_map.tsv
+++ b/tests/tai/evolverMammals_ancestor_name_map.tsv
@@ -1,0 +1,8 @@
+
+Anc0	Ancestor0
+Anc1	Ancestor1
+Anc2	Ancestor2
+Anc3	Ancestor3
+simCow	ERROR
+
+

--- a/tests/tai/evolverMammals_ancestor_rev_name_map.tsv
+++ b/tests/tai/evolverMammals_ancestor_rev_name_map.tsv
@@ -1,0 +1,7 @@
+Anc0	Ancestor0
+Ancestor0	Anc0
+Ancestor1	Anc1
+Ancestor2	Anc2
+Ancestor3	Anc3
+simCow	ERROR
+

--- a/tests/tai/test_tai.py
+++ b/tests/tai/test_tai.py
@@ -25,16 +25,22 @@ def maf_compare(maf_path_1, maf_path_2):
     subprocess.check_call(['rm', '-f', '{}.clean'.format(maf_path_2)])
         
         
-def test_region(taf_path, contig, start, end):
+def test_region(taf_path, contig, start, end, rev_name_map_path=None):
     assert os.path.isfile(maf_path)
 
     # extract the region right into maf
     out_path = './tests/tai/{}_{}_{}.taf.maf'.format(os.path.basename(os.path.splitext(maf_path)[0]), start, end)
-    subprocess.check_call('./bin/taffy view -i {} -r {}:{}-{} -m  > {}'.format(taf_path, contig, start, end, out_path), shell=True)
+    cmd = './bin/taffy view -i {} -r {}:{}-{} -m'.format(taf_path, contig, start, end)
+    if rev_name_map_path:
+        cmd += ' -n {}'.format(rev_name_map_path)
+    cmd += '  > {}'.format(out_path)
+    
+    subprocess.check_call(cmd, shell=True)
     assert os.path.isfile(out_path)
 
     # run the comparison.
     # this maf was made with ./evolverMammalsMakeSubregions.py
+    # note that we can run this query even on the renamed file because the rev_name_map contains both directions for Anc0!
     truth_path = './tests/tai/{}_{}_{}.maf'.format(os.path.basename(os.path.splitext(maf_path)[0]), start, end)
     assert os.path.isfile(truth_path)
     # sanity check to make sure we're not comparing empty files
@@ -50,7 +56,7 @@ def create_index(taf_path, block_size):
     subprocess.check_call(['./bin/taffy', 'index', '-i', taf_path, '-b', str(block_size)])
     assert os.path.isfile(taf_path + '.tai')
 
-def check_anc0_stats(stats_string):
+def check_anc0_stats(stats_string, renamed=False):
     true_string = '''Anc0.Anc0refChr0	4151
 Anc0.Anc0refChr10	14504
 Anc0.Anc0refChr11	38002
@@ -63,33 +69,65 @@ Anc0.Anc0refChr6	22717
 Anc0.Anc0refChr7	1851
 Anc0.Anc0refChr8	111467
 Anc0.Anc0refChr9	4824'''
+    if renamed:
+        true_string = true_string.replace('Anc0.Anc0', 'Ancestor0.Anc0')
     stats_string = '\n'.join(sorted(stats_string.strip().split('\n')))
     true_string = '\n'.join(sorted(true_string.strip().split('\n')))
     if stats_string != true_string:
         sys.stderr.write('\n    found stats:\n{}\n    different from true stats:\n{}\n'.format(stats_string, true_string))
     assert(stats_string == true_string)
     
-def test_tai(regions_path, taf_path, bgzip, block_size):
-    sys.stderr.write(" * running indexing/extraction tests on {} with bzgip={} and blocksize={}".format(taf_path, bgzip, block_size))
+def test_tai(regions_path, taf_path, bgzip, block_size, name_map_path=None, rev_name_map_path=None):
+    sys.stderr.write(" * running indexing/extraction tests on {} with bzgip={} and blocksize={} and rename={}".format(taf_path, bgzip, block_size, name_map_path != None))
+    assert (name_map_path == None) == (rev_name_map_path == None)
+    
     if bgzip:
         gz_path = taf_path + '.gz'
         subprocess.check_call('bgzip -c {} > {}'.format(taf_path, gz_path), shell=True)
         taf_path = gz_path
 
+    if name_map_path:
+        # run the name conversion
+        renamed_taf_path = taf_path + '.renamed'
+        if bgzip:
+            renamed_taf_path += '.gz'
+        cmd = ['taffy', 'view', '-i', taf_path, '-n', name_map_path, '-o', renamed_taf_path]
+        if bgzip:
+            cmd += ['-c']
+        subprocess.check_call(cmd)
+        pre_renamed_path = taf_path
+        taf_path = renamed_taf_path
+    
     create_index(taf_path, block_size)
 
     with open(regions_path, 'r') as regions_file:
         for line in regions_file:
             contig, start, end = line.split()[:3]
-            test_region(taf_path, contig, start, end)
+            test_region(taf_path, contig, start, end, rev_name_map_path=rev_name_map_path)
 
     seq_stats = subprocess.check_output(['./bin/taffy', 'stats', '-s', '-i', taf_path]).decode('utf-8')
-    check_anc0_stats(seq_stats)
+    check_anc0_stats(seq_stats, renamed=name_map_path != None)
 
     if bgzip:
         subprocess.check_call(['rm', '-f', taf_path])
     subprocess.check_call(['rm', '-f', taf_path + '.tai'])
-    sys.stderr.write("\t\t\tOK\n")    
+    if name_map_path:
+        subprocess.check_call(['rm', '-f', pre_renamed_path])
+    sys.stderr.write("\t\t\tOK\n")
+
+def test_tai_naming(regions_path, taf_path):
+    sys.stderr.write(" * running name mapping tests on {}".format(taf_path))
+
+    # rename the ancesstors
+    mapping_path = './tests/name-mapping.tsv'
+    with open(mapping_path, 'w') as mapping_file:
+        mapping_file.write('\nAnc0\tAncestor0\n')
+        mapping_file.write('Anc1\tAncestor1\n')
+        mapping_file.write('Anc2\tAncestor2\n')
+    renamed_taf_path = taf_path + '.renamed'        
+    subprocess.check_call(['./bin/taffy', 'view', '-i', taf_path, '-o', renamed_taf_path, '-n', mapping_path])
+
+                     
     
 sys.stderr.write("Running tai tests...\n")
 maf_path_in = './tests/evolverMammals.maf'
@@ -104,12 +142,16 @@ sys.stderr.write(" * creating run length encoded evolver taf {}".format(taf_rle_
 subprocess.check_call(['./bin/taffy', 'view', '-i', maf_path, '-o', taf_rle_path, '-u'])
 sys.stderr.write("\t\t\tOK\n")    
 regions_path = './tests/tai/evolverMammals_subregions.bed'
+name_map_path = './tests/tai/evolverMammals_ancestor_name_map.tsv'
+rev_name_map_path = './tests/tai/evolverMammals_ancestor_rev_name_map.tsv'
 
 test_tai(regions_path, taf_path, False, 111)
 test_tai(regions_path, taf_path, True, 200)
 test_tai(regions_path, taf_rle_path, False, 111)
 test_tai(regions_path, taf_rle_path, True, 200)
 test_tai(regions_path, maf_path, False, 111)
-test_tai(regions_path, maf_path, True, 200)
+test_tai(regions_path, maf_path, True, 200)                         
+test_tai(regions_path, maf_path, True, 200, name_map_path=name_map_path, rev_name_map_path=rev_name_map_path)
+
 
 subprocess.check_call(['rm', '-f', taf_path, taf_rle_path, maf_path])


### PR DESCRIPTION
This is the equivalent of `halRenameGenomes` but for MAF/TAF.  

You pass the 2-column TSV to `taffy view` via the new `-n` option, and it will rename the contig names in the alingment block accordingly.  

`.` characters get special treatment consistent with an `<assembly>.<contig>` naming scheme.  

So if the mapping has `hg38 -> Homo_sapiens` then `hg38.chr1` would get renamed to `Homo_sapiens.chr1` etc.  The naming also applies to input regions via the `taffy view -r` option.  So if the MAF/TAF is indexed along hg38, then you can search for `Homo_sapiens.chr1:10-100` via the name map.  

The goal for this is to make working with TAF/MAF files that use accessions for assembly names .

Since both the assembly and contig names can have "."s in them, it uses a a greedy resolver, scanning dots from left to right to find one that makes a prefix that's in the input map. 