### PR TITLE
Use abPOA for gap alignments

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 [submodule "taffy/submodules/sonLib"]
 	path = taffy/submodules/sonLib
 	url = https://github.com/ComparativeGenomicsToolkit/sonLib
+[submodule "taffy/submodules/abPOA"]
+	path = taffy/submodules/abPOA
+	url = https://github.com/yangao07/abPOA.git

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,28 @@ all_progs: all_libs ${BINDIR}/taffy
 
 sonLib: 
 	mkdir -p ${LIBDIR} ${BINDIR}
-	cd taffy/submodules/sonLib && PKG_CONFIG_PATH=${CWD}/lib/pkgconfig:${PKG_CONFIG_PATH} ${MAKE}
+	cd ${sonLibRootDir} && PKG_CONFIG_PATH=${CWD}/lib/pkgconfig:${PKG_CONFIG_PATH} ${MAKE}
 	mkdir -p ${BINDIR} ${LIBDIR} ${INCLDIR}
-	rm -rf taffy/submodules/sonLib/bin/*.dSYM
-	ln -f taffy/submodules/sonLib/lib/*.a ${LIBDIR}
-	ln -f taffy/submodules/sonLib/lib/sonLib.a ${LIBDIR}/libsonLib.a
+	rm -rf ${sonLibRootDir}/bin/*.dSYM
+	ln -f ${sonLibDir}/*.a ${LIBDIR}
+	ln -f ${sonLibDir}/sonLib.a ${LIBDIR}/libsonLib.a
 
 stTafDependencies = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
 
 ${sonLibDir}/sonLib.a : sonLib
 
 ${sonLibDir}/cuTest.a : sonLib
+
+abPOA:
+	mkdir -p ${LIBDIR} ${INCLDIR}
+	cd taffy/submodules/abPOA && ${MAKE}
+	ln -f taffy/submodules/abPOA/lib/*.a ${LIBDIR}
+	ln -f taffy/submodules/abPOA/include/*.h ${INCLDIR}
+	rm -fr ${INCLDIR}/simde && cp -r taffy/submodules/abPOA/include/simde ${INCLDIR}
+
+${LIBDIR}/libabpoa.a : abPOA
+
+stTafDependencies += ${LIBDIR}/libabpoa.a
 
 ${LIBDIR}/libstTaf.a : ${libTests} ${libHeaders} ${srcDir}/alignment_block.o ${srcDir}/line_iterator.o ${srcDir}/maf.o ${srcDir}/paf.o ${srcDir}/ond.o ${srcDir}/taf.o ${srcDir}/add_gap_bases.o ${srcDir}/merge_adjacent_alignments.o ${srcDir}/prefix_sort.o ${srcDir}/tai.o ${libHeaders} ${stTafDependencies}
 	${AR} rc libstTaf.a ${srcDir}/alignment_block.o ${srcDir}/line_iterator.o ${srcDir}/maf.o ${srcDir}/paf.o ${srcDir}/ond.o ${srcDir}/taf.o ${srcDir}/add_gap_bases.o ${srcDir}/merge_adjacent_alignments.o ${srcDir}/prefix_sort.o ${srcDir}/tai.o
@@ -93,7 +104,8 @@ python_test: all ${BINDIR}/stTafTests
 	cd tests && python3 taffyTest.py
 
 clean :
-	cd taffy/submodules/sonLib && ${MAKE} clean
+	cd ${sonLibRootDir} && ${MAKE} clean
+	cd taffy/submodules/abPOA && ${MAKE} clean
 	rm -rf *.o taffy/impl/*.o ${LIBDIR} ${BINDIR}
 
 static :

--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,6 @@ sonLib:
 	ln -f ${sonLibDir}/*.a ${LIBDIR}
 	ln -f ${sonLibDir}/sonLib.a ${LIBDIR}/libsonLib.a
 
-stTafDependencies = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
-
-${sonLibDir}/sonLib.a : sonLib
-
-${sonLibDir}/cuTest.a : sonLib
-
 abPOA:
 	mkdir -p ${LIBDIR} ${INCLDIR}
 	cd taffy/submodules/abPOA && ${MAKE}
@@ -33,7 +27,11 @@ abPOA:
 
 ${LIBDIR}/libabpoa.a : abPOA
 
-stTafDependencies += ${LIBDIR}/libabpoa.a
+${sonLibDir}/sonLib.a : sonLib
+
+${sonLibDir}/cuTest.a : sonLib
+
+stTafDependencies = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a ${LIBDIR}/libabpoa.a
 
 ${LIBDIR}/libstTaf.a : ${libTests} ${libHeaders} ${srcDir}/alignment_block.o ${srcDir}/line_iterator.o ${srcDir}/maf.o ${srcDir}/paf.o ${srcDir}/ond.o ${srcDir}/taf.o ${srcDir}/add_gap_bases.o ${srcDir}/merge_adjacent_alignments.o ${srcDir}/prefix_sort.o ${srcDir}/tai.o ${libHeaders} ${stTafDependencies}
 	${AR} rc libstTaf.a ${srcDir}/alignment_block.o ${srcDir}/line_iterator.o ${srcDir}/maf.o ${srcDir}/paf.o ${srcDir}/ond.o ${srcDir}/taf.o ${srcDir}/add_gap_bases.o ${srcDir}/merge_adjacent_alignments.o ${srcDir}/prefix_sort.o ${srcDir}/tai.o
@@ -57,7 +55,7 @@ ${srcDir}/ond.o : ${srcDir}/ond.c ${libHeaders}
 ${srcDir}/add_gap_bases.o : ${srcDir}/add_gap_bases.cpp ${libHeaders}
 	${CXX} ${CPPFLAGS} ${CXXFLAGS} -o ${srcDir}/add_gap_bases.o -c ${srcDir}/add_gap_bases.cpp
 
-${srcDir}/merge_adjacent_alignments.o : ${srcDir}/merge_adjacent_alignments.c ${libHeaders}
+${srcDir}/merge_adjacent_alignments.o : ${srcDir}/merge_adjacent_alignments.c ${libHeaders} abPOA
 	${CC} ${CFLAGS} ${LDFLAGS} -o ${srcDir}/merge_adjacent_alignments.o -c ${srcDir}/merge_adjacent_alignments.c
 
 ${srcDir}/taf.o : ${srcDir}/taf.c ${libHeaders}

--- a/include.mk
+++ b/include.mk
@@ -44,10 +44,10 @@ endif
 
 # Hack in ARM support
 # Toggle on if "arm" is set, or if uname -m returns aarch64
-ifeq ($(shell uname -m || true), aarch64)
+ifeq ($(shell uname -m || true), arm64)
 	arm=1
 endif
-ifeq ($(shell arch || true), aarch64)
+ifeq ($(shell arch || true), arm64)
 	arm=1
 endif
 ifdef arm

--- a/include.mk
+++ b/include.mk
@@ -92,6 +92,8 @@ LDLIBS += ${HTSLIB_LIBS}
 # libraries can't be added until they are build, so add as to LDLIBS until needed
 sonLibLibs = ${sonLibDir}/sonLib.a ${sonLibDir}/cuTest.a
 
+abpoaLibs = ${abpoaLibDir}/libapoa.a
+
 # optional hal support toggled on by setting HALDIR (ex to ../hal)
 ifdef HALDIR
 	LDLIBS += ${HALDIR}/lib/libHalBlockViz.a ${HALDIR}/lib/libHalLiftover.a ${HALDIR}/lib/libHalLod.a ${HALDIR}/lib/libHalMaf.a ${HALDIR}/lib/libHal.a
@@ -114,5 +116,5 @@ ifdef HALDIR
 endif
 
 # note: the CACTUS_STATIC_LINK_FLAGS below can generally be empty -- it's used by the static builder script only
-LDLIBS += ${sonLibLibs} ${LIBS} -L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -lz -lbz2 -lpthread -lm -lstdc++ -lm ${CACTUS_STATIC_LINK_FLAGS}
+LDLIBS += ${sonLibLibs} ${LIBS} -L${rootPath}/lib -Wl,-rpath,${rootPath}/lib -labpoa -lz -lbz2 -lpthread -lm -lstdc++ -lm ${CACTUS_STATIC_LINK_FLAGS}
 

--- a/taf_norm.c
+++ b/taf_norm.c
@@ -326,14 +326,14 @@ int taf_norm_main(int argc, char *argv[]) {
                 common_rows >= total_rows * fraction_shared_rows &&
                 (alignment_length(p_alignment) <= maximum_block_length_to_merge ||
                  alignment_length(alignment) <= maximum_block_length_to_merge)) {
-                int64_t total_gap = alignment_total_gap_length(p_alignment);
-                if (total_gap > maximum_gap_length && filter_gap_causing_dupes) {
+                int64_t max_gap = alignment_max_gap_length(p_alignment);
+                if (max_gap > maximum_gap_length && filter_gap_causing_dupes) {
                     // try to greedily filter dupes in order to get the gap length down
                     bool was_pruned = greedy_prune_by_gap(alignment, maximum_gap_length);
-                    total_gap = alignment_total_gap_length(p_alignment);
-                    assert(was_pruned == (total_gap <= maximum_gap_length));
+                    max_gap = alignment_max_gap_length(p_alignment);
+                    assert(was_pruned == (max_gap <= maximum_gap_length));
                 }
-                if (total_gap <= maximum_gap_length) {
+                if (max_gap <= maximum_gap_length) {
                     if(hal_species || fastas_map) { // Now add in any gap bases if sequences are provided
                         alignment_add_gap_strings(p_alignment, alignment, fastas_map, hal_handle, hal_species, -1);
                     }

--- a/taffy/_taffy_build.py
+++ b/taffy/_taffy_build.py
@@ -285,7 +285,7 @@ ffibuilder.set_source("taffy._taffy_cffi",
                                "taffy/submodules/sonLib/C/impl/sonLibFile.c",
                                "taffy/impl/line_iterator.c",
                                "taffy/impl/alignment_block.c",
-                               "taffy/impl/merge_adjacent_alignments.c",
+                               # "taffy/impl/merge_adjacent_alignments.c" - this is excluded because it uses abPOA
                                "taffy/impl/maf.c",
                                "taffy/impl/ond.c",
                                "taffy/impl/taf.c",

--- a/taffy/_taffy_build.py
+++ b/taffy/_taffy_build.py
@@ -114,7 +114,7 @@ ffibuilder.cdef("""
     /*
      * Gets the max length of an interstitial gap sequence between this block and the next one.
      */
-    int64_t alignment_total_gap_length(Alignment *left_alignment);
+    int64_t alignment_max_gap_length(Alignment *left_alignment);
     
     /*
      * Number of shared rows between two alignments

--- a/taffy/_taffy_build.py
+++ b/taffy/_taffy_build.py
@@ -122,14 +122,6 @@ ffibuilder.cdef("""
     int64_t alignment_number_of_common_rows(Alignment *left_alignment, Alignment *right_alignment);
     
     /*
-     * Merge together adjacent blocks into one alignment. Requires that the alignment
-     * rows are linked together (e.g. with alignment_link_adjacent). Destroys the input
-     * alignments in the process and returns a merged alignment. If there are interstitial
-     * sequences between the blocks, aligns these sequences together.
-     */
-    Alignment *alignment_merge_adjacent(Alignment *left_alignment, Alignment *right_alignment);
-    
-    /*
      * Cleanup a row
      */
     void alignment_row_destruct(Alignment_Row *row);

--- a/taffy/impl/alignment_block.c
+++ b/taffy/impl/alignment_block.c
@@ -231,7 +231,7 @@ int64_t alignment_length(Alignment *alignment) {
     return alignment->column_number;
 }
 
-int64_t alignment_total_gap_length(Alignment *left_alignment) {
+int64_t alignment_max_gap_length(Alignment *left_alignment) {
     Alignment_Row *l_row = left_alignment->row;
     int64_t total_interstitial_gap_length = 0;
     while(l_row != NULL) {

--- a/taffy/impl/merge_adjacent_alignments.c
+++ b/taffy/impl/merge_adjacent_alignments.c
@@ -103,16 +103,6 @@ int64_t align_interstitial_gaps(Alignment *alignment) {
         row = row->n_row;
     }
 
-    fprintf(stderr, "Nd input\n");
-    for (Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
-        if (row->left_gap_sequence == NULL) {
-            fprintf(stderr, "NULL\n");
-        } else {
-            fprintf(stderr, "%s\n", row->left_gap_sequence);
-        }
-    }
-
-
     // Find the longest gap sequence and number of sequences to align
     //TODO: Consider not allowing picking the longest sequence if it is all Ns
     row = alignment->row;
@@ -190,16 +180,6 @@ int64_t align_interstitial_gaps(Alignment *alignment) {
         row = row->n_row;
     }
 
-    fprintf(stderr, "Output\n");
-    for (Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
-        if (row->left_gap_sequence == NULL) {
-            fprintf(stderr, "NULL\n");
-        } else {
-            fprintf(stderr, "%s\n", row->left_gap_sequence);
-        }
-    }
-
-    
     for (int64_t i = 0; i < string_no; ++i) {
         free(msa[i]);
     }
@@ -338,15 +318,6 @@ int64_t align_interstitial_gaps_abpoa(Alignment *alignment) {
         }
     }
 
-    fprintf(stderr, "Nd input\n");
-    for (Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
-        if (row->left_gap_sequence == NULL) {
-            fprintf(stderr, "NULL\n");
-        } else {
-            fprintf(stderr, "%s\n", row->left_gap_sequence);
-        }
-    }
-
     if (seq_no == 0) {
         return 0;
     }
@@ -394,16 +365,6 @@ int64_t align_interstitial_gaps_abpoa(Alignment *alignment) {
         }
         row->left_gap_sequence[msa_length] = '\0';
     }
-
-    fprintf(stderr, "Output\n");
-    for (Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
-        if (row->left_gap_sequence == NULL) {
-            fprintf(stderr, "NULL\n");
-        } else {
-            fprintf(stderr, "%s\n", row->left_gap_sequence);
-        }
-    }
-
 
     // free abpoa
     abpoa_free(ab);

--- a/taffy/impl/merge_adjacent_alignments.c
+++ b/taffy/impl/merge_adjacent_alignments.c
@@ -103,6 +103,16 @@ int64_t align_interstitial_gaps(Alignment *alignment) {
         row = row->n_row;
     }
 
+    fprintf(stderr, "Nd input\n");
+    for (Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+        if (row->left_gap_sequence == NULL) {
+            fprintf(stderr, "NULL\n");
+        } else {
+            fprintf(stderr, "%s\n", row->left_gap_sequence);
+        }
+    }
+
+
     // Find the longest gap sequence and number of sequences to align
     //TODO: Consider not allowing picking the longest sequence if it is all Ns
     row = alignment->row;
@@ -179,6 +189,17 @@ int64_t align_interstitial_gaps(Alignment *alignment) {
         }
         row = row->n_row;
     }
+
+    fprintf(stderr, "Output\n");
+    for (Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+        if (row->left_gap_sequence == NULL) {
+            fprintf(stderr, "NULL\n");
+        } else {
+            fprintf(stderr, "%s\n", row->left_gap_sequence);
+        }
+    }
+
+    
     for (int64_t i = 0; i < string_no; ++i) {
         free(msa[i]);
     }
@@ -317,6 +338,15 @@ int64_t align_interstitial_gaps_abpoa(Alignment *alignment) {
         }
     }
 
+    fprintf(stderr, "Nd input\n");
+    for (Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+        if (row->left_gap_sequence == NULL) {
+            fprintf(stderr, "NULL\n");
+        } else {
+            fprintf(stderr, "%s\n", row->left_gap_sequence);
+        }
+    }
+
     if (seq_no == 0) {
         return 0;
     }
@@ -333,7 +363,10 @@ int64_t align_interstitial_gaps_abpoa(Alignment *alignment) {
     for (Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
         if (row->left_gap_sequence != NULL && row->left_gap_sequence[0] != '\0') {
             seq_lens[row_idx] = strlen(row->left_gap_sequence);
-            bseqs[row_idx] = (uint8_t*)st_calloc(seq_lens[row_idx], sizeof(uint8_t));            
+            bseqs[row_idx] = (uint8_t*)st_calloc(seq_lens[row_idx], sizeof(uint8_t));
+            for (int64_t col = 0; col < seq_lens[row_idx]; ++col) {
+                bseqs[row_idx][col] = msa_to_byte(row->left_gap_sequence[col]);
+            }
             ++row_idx;
         }
     }
@@ -346,20 +379,31 @@ int64_t align_interstitial_gaps_abpoa(Alignment *alignment) {
     int64_t msa_length = ab->abc->msa_len;
     row_idx = 0;
     for (Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+        bool empty_row = row->left_gap_sequence == NULL || row->left_gap_sequence[0] == '\0';
         free(row->left_gap_sequence);
         row->left_gap_sequence = (char*)st_calloc(msa_length + 1, sizeof(char));        
-        if (row->left_gap_sequence != NULL && row->left_gap_sequence[0] != '\0') {
+        if (!empty_row) {
             for (int64_t col = 0; col < msa_length; ++col) {
                 row->left_gap_sequence[col] = msa_to_base(ab->abc->msa_base[row_idx][col]);
             }
+            ++row_idx;
         } else {
             for (int64_t col = 0; col < msa_length; ++col) {
                 row->left_gap_sequence[col] = '-';
             }
         }
         row->left_gap_sequence[msa_length] = '\0';
-        ++row_idx;
     }
+
+    fprintf(stderr, "Output\n");
+    for (Alignment_Row *row = alignment->row; row != NULL; row = row->n_row) {
+        if (row->left_gap_sequence == NULL) {
+            fprintf(stderr, "NULL\n");
+        } else {
+            fprintf(stderr, "%s\n", row->left_gap_sequence);
+        }
+    }
+
 
     // free abpoa
     abpoa_free(ab);

--- a/taffy/inc/taf.h
+++ b/taffy/inc/taf.h
@@ -99,7 +99,7 @@ int64_t alignment_length(Alignment *alignment);
 /*
  * Gets the max length of an interstitial gap sequence between this block and the next one.
  */
-int64_t alignment_total_gap_length(Alignment *left_alignment);
+int64_t alignment_max_gap_length(Alignment *left_alignment);
 
 /*
  * Number of shared rows between two alignments

--- a/tests/normalize_test.c
+++ b/tests/normalize_test.c
@@ -27,10 +27,10 @@ static void test_normalize(CuTest *testCase) {
             alignment_link_adjacent(p_alignment, alignment, 0);
 
             // And the expected length of the alignment
-            int64_t combined_alignment_length = alignment_length(p_alignment) + alignment_length(alignment) + alignment_total_gap_length(p_alignment);
+            int64_t combined_alignment_length = alignment_length(p_alignment) + alignment_length(alignment) + alignment_max_gap_length(p_alignment);
 
             if((alignment_length(p_alignment) < 50 || alignment_length(alignment) < 50) &&
-                alignment_total_gap_length(p_alignment) < 50) {
+                alignment_max_gap_length(p_alignment) < 50) {
 
                 // Calculate the number of expected rows and get list of row coordinates
                 uint64_t combined_alignment_rows=0;


### PR DESCRIPTION
This replaces the wfa-based gap sequence aligner with abPOA.  The default cactus scoring parameters are hardcoded in. It passes all tests but I haven't yet tested it at scale.    In particular it will only work to about ~100kb  -- should be fine in practice but at the very least needs an explicit check. 

@benedictpaten do you mind testing it builds and runs for you? 

As an aside, it wouldn't even pass the tests until I sorted the abpoa input by length -- the problem case is below: 
```
printf ">1\nNNNNNNNNNNNNN\n>2\nNNNNNNNNNNNNNNNNNNN\n>3\nNNNNNNNNNNNNNN\n" > x.fa
taffy/submodules/abPOA/bin/abpoa -r 1 -m 0 x.fa
[main] CMD:  taffy/submodules/abPOA/bin/abpoa -r 1 -m 0 x.fa
>1
NNNNNNNNNNNNN-------
>2
NNNNNNNNNNNNN-NNNNNN
>3
NNNNNNNNNNNNNN------
[abpoa_main] Real time: 0.001 sec; CPU: 0.005 sec; Peak RSS: 0.004 GB.
```
but sorting works
```
printf ">2\nNNNNNNNNNNNNNNNNNNN\n>3\nNNNNNNNNNNNNNN\n>1\nNNNNNNNNNNNNN\n" > x.sort.fa
taffy/submodules/abPOA/bin/abpoa -r 1 -m 0 x.sort.fa
[main] CMD:  taffy/submodules/abPOA/bin/abpoa -r 1 -m 0 x.sort.fa
>2
NNNNNNNNNNNNNNNNNNN
>3
NNNNNNNNNNNNNN-----
>1
NNNNNNNNNNNNN------
[abpoa_main] Real time: 0.001 sec; CPU: 0.005 sec; Peak RSS: 0.004 GB.
```
