### PR TITLE
add CACTUS_LEGACY_ARCH toggle to disable avx2

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -51,17 +51,29 @@ ifeq ($(shell arch || true), arm64)
 	arm=1
 endif
 ifdef arm
-# flags to build abpoa
-export armv8 = 1
-export aarch64 = 1
-# flags to include simde abpoa in cactus on ARM
-CFLAGS+= -march=armv8-a+simd
+#	flags to build abpoa
+	export armv8 = 1
+	export aarch64 = 1
+#	flags to include simde abpoa in cactus on ARM
+	CFLAGS+= -march=armv8-a+simd
 else
-# flags to build abpoa
-export avx2 = 1
+	ifdef CACTUS_LEGACY_ARCH
+		export sse2 = 1
+		CFLAGS+= -msse2
+	else
+#		flags to build abpoa
+		export avx2 = 1
+#		flags to include simde abpoa in cactus on X86
+		CFLAGS+= -mavx2
 endif
+endif
+
 # flags needed to include simde abpoa in cactus on any architecture
-CFLAGS+= -D__AVX2__ -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES
+ifdef CACTUS_LEGACY_ARCH
+	CFLAGS+= -D__SSE2__ -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES
+else
+	CFLAGS+= -D__AVX2__ -DUSE_SIMDE -DSIMDE_ENABLE_NATIVE_ALIASES
+endif
 
 dataSetsPath=/Users/benedictpaten/Dropbox/Documents/work/myPapers/genomeCactusPaper/dataSets
 


### PR DESCRIPTION
I'm copying this directly from Cactus's `include.mk` so that taffy will use the same toggle to switch abpoa between sse2 and avx2.  This is required to integrate taffy [into cactus](https://github.com/ComparativeGenomicsToolkit/cactus/pull/1285), and even for Cactus's [CI tests to run](https://ucsc-ci.com/comparativegenomicstoolkit/cactus/-/pipelines/6292).