### PR TITLE
Fix bug where tai index query could return block with incorrect column_number

### DIFF
--- a/taffy/impl/tai.c
+++ b/taffy/impl/tai.c
@@ -543,14 +543,12 @@ static unsigned int clip_alignment(Alignment *aln, Alignment *p_aln, int64_t sta
             }
             assert(strlen(row->bases) >= row->length);            
         }
-        aln->column_number -= left_trim;
     }
 
     //clip the right side
     int64_t right_trim = (aln->row->start + aln->row->length) - end;
     if (right_trim > 0) {
         ret = ret | 1;
-        assert(aln->column_number > right_trim);
 
         // we need to find the cut point by counting off right_trim non-gap bases from the end of the reference row
         int64_t cut_point = strlen(aln->row->bases) - 1;
@@ -577,7 +575,6 @@ static unsigned int clip_alignment(Alignment *aln, Alignment *p_aln, int64_t sta
             }
             assert(strlen(row->bases) >= row->length);
         }
-        aln->column_number -= right_trim;                
     }
 
     // now we make sure any deleted rows are unlinked from prev alignment.
@@ -606,8 +603,9 @@ static unsigned int clip_alignment(Alignment *aln, Alignment *p_aln, int64_t sta
             prev = row;
         }
     }
-    assert(aln->column_number > 0);
-    
+
+    aln->column_number = aln->row_number > 0 ? strlen(aln->row->bases) : 0;
+
     return ret;
 }
 
@@ -640,7 +638,7 @@ Alignment *tai_next(TaiIt *tai_it, LI *li) {
             tai_it->alignment = NULL;
         }
     }
-    
+
     return tai_it->p_alignment;
 }
 


### PR DESCRIPTION
Range queries on the tai index require clipping alignment blocks.  There was a bug where the block clipping would adjust the alignment's `column_number` field by the number of clipped bases, but not accounting for gaps.

This never came up before because the only tool using the index was `taffy view`, which ignores `column_number` completely and just prints out the block sequences and coordinates which are correct (and the tests all use `taffy view` too).  

But it leads to a crash when trying to iterate columns with the python API, ex (thanks Konstantinos):
```
taffy view -i taffy/tests/evolverMammals.maf | taffy norm -o evolverMammals_norm.taf
taffy index -i  evolverMammals_norm.taf
```
Then run this python script will fail because `block.column_number()` returns the wrong value
```
import pathlib
from taffy.lib import AlignmentReader
from taffy.lib import TafIndex

with AlignmentReader('evolverMammals.taf', taf_index='evolverMammals.taf.tai', sequence_name="Anc0.Anc0refChr0", start=502, length=83) as mp:
    for block in mp:
        for j in range(block.column_number()):
            print(block.get_column(j))
```