### PR TITLE
add std=c++11 to cxxflags to hopefully fix mac build

### DIFF
--- a/include.mk
+++ b/include.mk
@@ -30,7 +30,7 @@ include ${sonLibRootDir}/include.mk
 #Turn asserts back on in spite of sonLib
 #https://github.com/ComparativeGenomicsToolkit/cactus/issues/235
 CFLAGS += -UNDEBUG
-CXXFLAGS += -UNDEBUG
+CXXFLAGS += -UNDEBUG -std=c++11
 
 ifndef TARGETOS
   TARGETOS := $(shell uname -s)

--- a/taf_sort.c
+++ b/taf_sort.c
@@ -29,7 +29,7 @@ stList *load_sort_file(char *sort_file) {
     FILE *sort_fh = fopen(sort_file, "r");
     if (sort_fh == NULL) {
         fprintf(stderr, "Unable to open sort/filter file: %s\n", sort_file);
-        return 1;
+        exit(1);
     }
     stList *prefixes_to_sort_by = sequence_prefix_load(sort_fh);
     st_logInfo("Loaded the sort/filter file, got %i rows\n", (int) stList_length(prefixes_to_sort_by));

--- a/taffy/impl/tai.c
+++ b/taffy/impl/tai.c
@@ -618,8 +618,7 @@ Alignment *tai_next(TaiIt *tai_it, LI *li) {
 
     // start by clamping the alignment block to the region
     assert(strcmp(tai_it->alignment->row->sequence_name, tai_it->name) == 0);
-    unsigned int ret = clip_alignment(tai_it->alignment, tai_it->p_alignment, tai_it->start, tai_it->end);
-
+    
     // save this alignment, it's what we're gonna return
     tai_it->p_alignment = tai_it->alignment;
 
@@ -629,7 +628,7 @@ Alignment *tai_next(TaiIt *tai_it, LI *li) {
     }
     
     // scan forward
-    if (ret & 1) {
+    if (tai_it->alignment->row->start + tai_it->alignment->row->length > tai_it->end) {
         tai_it->alignment = NULL;
     } else {
         tai_it->alignment = maftaf_read_block(tai_it->p_alignment, tai_it->run_length_encode_bases, li);
@@ -640,6 +639,9 @@ Alignment *tai_next(TaiIt *tai_it, LI *li) {
             tai_it->alignment = NULL;
         }
     }
+
+    // clip the alignment (done after read_block, which needs unclipped prev blocks for coordinate transform)
+    clip_alignment(tai_it->p_alignment, NULL, tai_it->start, tai_it->end);
     
     return tai_it->p_alignment;
 }

--- a/tests/tai/evolverMammals_400_405.maf
+++ b/tests/tai/evolverMammals_400_405.maf
@@ -1,0 +1,20 @@
+##maf version=1
+
+a score=0 mafExtractor_splicedBlock=true splice_id=35_0
+s Anc0.Anc0refChr0                  400  2 +    4151 Ag
+s Anc1.Anc1refChr1               293116  2 +  296994 Ag
+s Anc2.Anc2refChr1                  432  2 +    4655 Ag
+s simCow_chr6.simCow.chr6        597817  2 +  602619 ag
+s simDog_chr6.simDog.chr6        589523  1 +  593897 A-
+s simHuman_chr6.simHuman.chr6    597786  2 +  601863 AG
+
+a score=0 mafExtractor_splicedBlock=true splice_id=36_0
+s Anc0.Anc0refChr0                  402  3 +    4151 caa
+s Anc1.Anc1refChr1               293118  3 +  296994 Caa
+s Anc2.Anc2refChr1                  434  3 +    4655 caa
+s mr.mrrefChr1                   178613  1 +  182340 C--
+s simCow_chr6.simCow.chr6        597826  3 +  602619 caa
+s simHuman_chr6.simHuman.chr6    597788  3 +  601863 CAA
+s simMouse_chr6.simMouse.chr6    631031  1 +  636262 C--
+s simRat_chr6.simRat.chr6        642483  1 +  647215 C--
+

--- a/tests/tai/evolverMammals_410_415.maf
+++ b/tests/tai/evolverMammals_410_415.maf
@@ -1,0 +1,18 @@
+##maf version=1
+
+a score=0 mafExtractor_splicedBlock=true splice_id=37_0
+s Anc0.Anc0refChr0                  410  3 +    4151 AAT
+s Anc1.Anc1refChr1               293126  3 +  296994 AAT
+s Anc2.Anc2refChr1                  442  3 +    4655 AAT
+s simCow_chr6.simCow.chr6        597841  3 +  602619 aat
+s simDog_chr6.simDog.chr6        589524  3 +  593897 AAT
+s simHuman_chr6.simHuman.chr6    597796  3 +  601863 AAT
+
+a score=0 mafExtractor_splicedBlock=true splice_id=38_0
+s Anc0.Anc0refChr0                  413  2 +    4151 cA
+s Anc1.Anc1refChr1               293129  2 +  296994 cA
+s Anc2.Anc2refChr1                  445  2 +    4655 cA
+s simCow_chr6.simCow.chr6        597846  2 +  602619 ca
+s simDog_chr6.simDog.chr6        589527  1 +  593897 -A
+s simHuman_chr6.simHuman.chr6    597799  2 +  601863 CA
+

--- a/tests/tai/evolverMammals_subregions.bed
+++ b/tests/tai/evolverMammals_subregions.bed
@@ -1,5 +1,7 @@
 Anc0.Anc0refChr0	0	23
 Anc0.Anc0refChr0	125	259
+Anc0.Anc0refChr0	400	405
+Anc0.Anc0refChr0	410	415
 Anc0.Anc0refChr0	4000	4151
 Anc0.Anc0refChr0	4100	5000
 Anc0.Anc0refChr1	511	512

--- a/tests/tai/test_tai.py
+++ b/tests/tai/test_tai.py
@@ -127,7 +127,24 @@ def test_tai_naming(regions_path, taf_path):
     renamed_taf_path = taf_path + '.renamed'        
     subprocess.check_call(['./bin/taffy', 'view', '-i', taf_path, '-o', renamed_taf_path, '-n', mapping_path])
 
+
+def test_tai_taf_1bp_extractions(taf_path, maf_path, step):
+    """ do a bunch of 1bp queries to make sure taf is same as maf """
+    chr_name = 'Anc0.Anc0refChr0'
+    chr_length = 4151
+    sys.stderr.write(" * running TAF/MAF indexing/extraction comparison tests on {} with step {}".format(chr_name, step))
+
+    create_index(taf_path, 10000)
+    create_index(maf_path, 10000)
+    for pos in range(0, chr_length, step):
+        out_maf_path = './tests/tai/test_{}_{}.maf.taf'.format(chr_name, chr_length)
+        out_taf_path = './tests/tai/test_{}_{}.taf.taf'.format(chr_name, chr_length)        
+        subprocess.check_call(['./bin/taffy', 'view', '-i', maf_path, '-o', out_maf_path, '-r', '{}:{}'.format(chr_name, pos)])
+        subprocess.check_call(['./bin/taffy', 'view', '-i', taf_path, '-o', out_taf_path, '-r', '{}:{}'.format(chr_name, pos)])
+        subprocess.check_call(['diff', out_maf_path, out_taf_path])
+        subprocess.check_call(['rm', '-f', out_maf_path, out_taf_path])
                      
+    sys.stderr.write("\t\t\tOK\n")                     
     
 sys.stderr.write("Running tai tests...\n")
 maf_path_in = './tests/evolverMammals.maf'
@@ -152,6 +169,6 @@ test_tai(regions_path, taf_rle_path, True, 200)
 test_tai(regions_path, maf_path, False, 111)
 test_tai(regions_path, maf_path, True, 200)                         
 test_tai(regions_path, maf_path, True, 200, name_map_path=name_map_path, rev_name_map_path=rev_name_map_path)
-
+test_tai_taf_1bp_extractions(taf_path, maf_path, 5)
 
 subprocess.check_call(['rm', '-f', taf_path, taf_rle_path, maf_path])


### PR DESCRIPTION
@benedictpaten I hope this fixes the warnings like 
```
taff_coverage.cpp:469:34: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
            for (int64_t max_gap : contig_gap_thresholds) {
```