### PR TITLE
fix invalid region checker to catch 0-length interval

### DIFF
--- a/taf_view.c
+++ b/taf_view.c
@@ -300,8 +300,9 @@ int taf_view_main(int argc, char *argv[]) {
         Tai* tai = tai_load(tai_fh, !taf_input);
 
         TaiIt *tai_it = tai_iterator(tai, li, run_length_encode_input_bases, region_seq, region_start, region_length);
-        if (tai_it == NULL) {
-            fprintf(stderr, "Region %s:%" PRIi64 "-%" PRIi64 " not found in taffy index\n", region_seq, region_start, region_length);
+        if (!tai_has_next(tai_it)) {
+            fprintf(stderr, "Region %s:%" PRIi64 "-%" PRIi64 " not found in taffy index\n", region_seq, region_start,
+                    region_start + region_length);
             return 1;
         }
         Alignment *alignment = NULL;

--- a/taffy/impl/tai.c
+++ b/taffy/impl/tai.c
@@ -52,7 +52,7 @@ char *tai_parse_region(const char *region, int64_t *start, int64_t *length) {
             }
         }
     }
-    return contig_length > 0 ? stString_getSubString(region, 0, contig_length) : NULL;
+    return contig_length > 0 && *length > 0 && *start >=0 ? stString_getSubString(region, 0, contig_length) : NULL;
 }
 
 // gets the "reference" (first row) coordinate information

--- a/taffy/impl/tai.c
+++ b/taffy/impl/tai.c
@@ -393,6 +393,13 @@ TaiIt *tai_iterator(Tai* tai, LI *li, bool run_length_encode_bases, const char *
     tai_it->start = start;
     tai_it->end = length < 0 ? LONG_MAX : start + length;
     tai_it->run_length_encode_bases = run_length_encode_bases;
+    tai_it->alignment = NULL;
+    tai_it->p_alignment = NULL;
+
+    // no sense querying anything if length is empty
+    if (length <= 0) {
+        return tai_it;
+    }
 
     // look up the region in the taf index, which takes a dummy record
     TaiRec qr;
@@ -408,8 +415,7 @@ TaiIt *tai_iterator(Tai* tai, LI *li, bool run_length_encode_bases, const char *
             // there's no chance of finding the region as its contig isn't
             // in the index or its start position is too low
             // up to caller to spit out an error
-            tai_iterator_destruct(tai_it);
-            return NULL;
+            return tai_it;
         }
     }
 
@@ -483,17 +489,6 @@ TaiIt *tai_iterator(Tai* tai, LI *li, bool run_length_encode_bases, const char *
     if (p_alignment != NULL) {
         alignment_destruct(p_alignment, true);
         p_alignment = NULL;
-    }
-
-    // we scanned past our region, which could happen if your taf doesn't contain the whole
-    // sequence -- jsut return nothing
-    if (tai_it->alignment == NULL) {
-        if (tai_it->p_alignment) {
-            alignment_destruct(tai_it->p_alignment, true);
-        }
-        tai_iterator_destruct(tai_it);
-        st_logInfo("Scanned %" PRIi64 " blocks to NOT find region start in %" PRIi64 " seconds\n", scan_block_count, time(NULL) - start_time);
-        return NULL;
     }
 
     st_logInfo("Scanned %" PRIi64 " blocks to find region start in %" PRIi64 " seconds\n", scan_block_count, time(NULL) - start_time);
@@ -642,6 +637,10 @@ Alignment *tai_next(TaiIt *tai_it, LI *li) {
     clip_alignment(tai_it->p_alignment, NULL, tai_it->start, tai_it->end);
     
     return tai_it->p_alignment;
+}
+
+bool tai_has_next(TaiIt *tai_it) {
+    return tai_it->alignment != NULL;
 }
 
 void tai_iterator_destruct(TaiIt *tai_it) {

--- a/taffy/inc/tai.h
+++ b/taffy/inc/tai.h
@@ -63,6 +63,7 @@ void tai_destruct(Tai* idx);
  * Query the taf index
  * start is 0-based
  * length can be -1 for everything
+ * If the given start point is not in the index, returns an "empty" iterator (tai_next returns NULL).
  */
 TaiIt *tai_iterator(Tai* idx, LI *li, bool run_length_encode_bases, const char *contig, int64_t start, int64_t length);
 
@@ -70,7 +71,12 @@ TaiIt *tai_iterator(Tai* idx, LI *li, bool run_length_encode_bases, const char *
  * Iterate through a region as obtained via the iterator
  */
 Alignment *tai_next(TaiIt *tai_it, LI *li);
-                    
+
+/*
+ * Check if tai_next() is not NULL
+ */
+bool tai_has_next(TaiIt *tai_it);
+
 /*
  * Free a tai iterator
  */


### PR DESCRIPTION
This makes two changes:
* `taffy view` exits with error message if a 0-length interval passed in (instead of crashing)
* `tai` API returns empty iterator if input range not found in index (instead of returning `NULL` or, in the case of 0-len, crashing).  `tai_has_next()` can check for empty iterator