### PR TITLE
Option to print BED intervals of reference covered by TAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,15 @@ Taffy view first converts the input maf to TAF, taffy sort then sorts the rows o
 
 Where here we additionally remove any rows with sequence names with a prefix contained in the given FILTER_FILE.
 
+## Taffy Statistics
+
+`taffy stats` can print some basic statistics about the reference contigs (first row) in the alignment. Options are
+* List the reference contigs and their lengths (maximum end coordinates as found in the alignment -- could be smaller than true contig lengths). This is done quickly using the `.tai` index created with `taffy index`.
+* List all the reference intervals in BED format found in the alignment.  This is done by scanning the whole alignment and is therefore much slower than the above option (but will produce more fine-grained output in the case where the alignment only covers subregions of the contigs).
+
 ## Taffy Coverage
 
-This tool calculates basic coverage and percent identity statistics of a selected reference (defaults to first row) vs all other genomes in the alignment. Whole-genome and reference-contig-level statistics are provided. The values presented are:
+This tool, `taffy coverage`, calculates basic coverage and percent identity statistics of a selected reference (defaults to first row) vs all other genomes in the alignment. Whole-genome and reference-contig-level statistics are provided. The values presented are:
 
 * `ref-contig`: full name of reference contig (`_Total_` for whole-genome numbers)
 * `max-gap`: reference bases in alignment gaps greater than this value are not counted in `len`.  

--- a/taf_stats.c
+++ b/taf_stats.c
@@ -15,6 +15,7 @@ static void usage(void) {
     fprintf(stderr, "Print statistics from a TAF or MAF file\n");
     fprintf(stderr, "-i --inputFile : Input TAF or MAF file. If not specified reads from stdin\n");
     fprintf(stderr, "-s --sequenceLengths : Print length of each *reference* sequence in the (indexed) alignment\n");
+    fprintf(stderr, "-b --sequenceIntervals : Print the BED intervals of each *reference* sequence covered by the alignment\n");
     fprintf(stderr, "-l --logLevel : Set the log level\n");
     fprintf(stderr, "-h --help : Print this help message\n");
 }
@@ -28,6 +29,8 @@ int taf_stats_main(int argc, char *argv[]) {
     char *logLevelString = NULL;
     char *taf_fn = NULL;
     bool seq_lengths = false;
+    bool seq_intervals = false;
+    int stat_option_count = 0;
 
     ///////////////////////////////////////////////////////////////////////////
     // Parse the inputs
@@ -37,11 +40,12 @@ int taf_stats_main(int argc, char *argv[]) {
         static struct option long_options[] = { { "logLevel", required_argument, 0, 'l' },
                                                 { "inputFile", required_argument, 0, 'i' },
                                                 { "sequenceLengths", no_argument, 0, 's' },
+                                                { "sequenceIntervals", no_argument, 0, 'b' },
                                                 { "help", no_argument, 0, 'h' },
                                                 { 0, 0, 0, 0 } };
 
         int option_index = 0;
-        int64_t key = getopt_long(argc, argv, "l:i:sh", long_options, &option_index);
+        int64_t key = getopt_long(argc, argv, "l:i:sbh", long_options, &option_index);
         if (key == -1) {
             break;
         }
@@ -55,7 +59,12 @@ int taf_stats_main(int argc, char *argv[]) {
                 break;
             case 's':
                 seq_lengths = 1;
+                ++stat_option_count;
                 break;
+            case 'b':
+                seq_intervals = 1;
+                ++stat_option_count;
+                break;                
             case 'h':
                 usage();
                 return 0;
@@ -76,8 +85,8 @@ int taf_stats_main(int argc, char *argv[]) {
     // Do the stats
     //////////////////////////////////////////////
 
-    if (seq_lengths == false) {
-        fprintf(stderr, "Please pick a stats option from { -s }\n");
+    if (stat_option_count != 1) {
+        fprintf(stderr, "Please pick a stats option from { -s, -b }\n");
         return 1;
     }
     
@@ -88,13 +97,21 @@ int taf_stats_main(int argc, char *argv[]) {
         return 1;
     }
     LI *li = LI_construct(taf_fh);
-    
+
     // sniff the format
     int input_format = check_input_format(LI_peek_at_next_line(li));
     if (input_format == 2) {
         fprintf(stderr, "Input not supported: unable to detect ##maf or #taf header\n");
         return 1;
+    } else if (input_format != 0 && seq_intervals) {
+        fprintf(stderr, "MAF input detected but -b only works with TAF input. Please use taffy view to convert\n");
+        return 1;
     }
+
+    // parse the header
+    bool run_length_encode_bases;
+    Tag *tag = taf_read_header_2(li, &run_length_encode_bases);
+    tag_destruct(tag);
 
     // load the index if it's required by the given options
     bool index_required = seq_lengths;
@@ -121,6 +138,38 @@ int taf_stats_main(int argc, char *argv[]) {
         }
         stHash_destruct(seq_to_len);
         stList_destruct(seq_names);
+    } else if (seq_intervals) {
+        Alignment *alignment = NULL;
+        Alignment *p_alignment = NULL;
+        char *cur_seq = NULL;
+        int64_t cur_start = -1;
+        int64_t cur_end = 0;
+        while((alignment = taf_read_block(p_alignment, run_length_encode_bases, li)) != NULL) {
+            if (alignment->row_number > 0) {
+                if (!cur_seq || strcmp(cur_seq, alignment->row->sequence_name) != 0 || alignment->row->start != cur_end) { 
+                    if (cur_seq) {
+                        fprintf(stdout, "%s\t%" PRIi64 "\t%" PRIi64 "\n", cur_seq, cur_start, cur_end);
+                        free(cur_seq);
+                    }
+                    cur_seq = stString_copy(alignment->row->sequence_name);
+                    cur_start = alignment->row->start;
+                    cur_end = cur_start + alignment->row->length;
+                } else {
+                    cur_end += alignment->row->length;
+                }
+            }
+            if (p_alignment) {
+                alignment_destruct(p_alignment, true);
+            }
+            p_alignment = alignment;
+        }
+        if (p_alignment) {
+            alignment_destruct(p_alignment, true);
+        }
+        if (cur_seq) {
+            fprintf(stdout, "%s\t%" PRIi64 "\t%" PRIi64 "\n", cur_seq, cur_start, cur_end);            
+            free(cur_seq);            
+        }
     }
 
         

--- a/taffy/inc/tai.h
+++ b/taffy/inc/tai.h
@@ -3,9 +3,38 @@
 
 /*
  * Index a TAF file.  Modeled on .fai from samtools faidx
- * Index format is 
- * Sequence Length Offset Mean-Row-Length TAF-header
- * where TAF header is everything we need to get going parsing the TAF file at that exact position
+ * 
+ * Each line represents a position on a reference contig as mapped to a position in the TAF/MAF file
+ * 
+ * The lines must be increasing in [Contig-Name, Start-position] order. 
+ *
+ * Lines can reflect absolute coordinates or relative coordinates. 
+ *
+ * Absoluate Coordinates:
+ *
+ * Column 1: Contig Name
+ * Column 2: Position in Contig (0-based)
+ * Column 3: Offset in bytes in MAF/TAF file being indexed (can be bgzipped)
+ *
+ * Relative coordinates (to the previous line):
+ *
+ * Column 1: *
+ * Column 2: Positiion in Contig *relative to previous line*
+ * Column 3: Offset in file *relative to previous line*
+ *
+ * For example, ths index:
+
+Anc0.Anc0refChr11	0	1421634189773
+*	10007	25769835729
+*	10001	30064728450
+*	10077	30064782171
+
+* is equivalent to:
+
+Anc0.Anc0refChr11	0	1421634189773
+Anc0.Anc0refChr11	10007	1447404025502
+Anc0.Anc0refChr11	20008	30064728450
+Anc0.Anc0refChr11	30085	30064782171
  *
  */
 


### PR DESCRIPTION
@benedictpaten Unfortunately this *isn't* the functionality you wanted in that it does not use the index, rather it requires a scan of the whole file.  

So you have the choice of 
* `taffy stats -s` : use the index to quickly get list of reference contig names and their (estimated) lengths
* `taffy stats -b` : print out a bed of all reference intervals (but requires a full scan).  

Putting the intervals themselves in the index requires a fairly major refactor (more than I'd initially thought)-- certainly possible, but not something I want to tackle this week if I can avoid it.  