### PR TITLE
error handling when index needed but input stdin

### DIFF
--- a/taf_stats.c
+++ b/taf_stats.c
@@ -126,6 +126,10 @@ int taf_stats_main(int argc, char *argv[]) {
     FILE *tai_fh = NULL;
     Tai *tai = NULL;
     if (index_required) {
+        if (taf_fn == NULL) {
+            fprintf(stderr, "An index is needed to compute the requested stats so an input filename must be specified with -i\n");
+            return 1;
+        }
         tai_fn = tai_path(taf_fn);
         tai_fh = fopen(tai_fn, "r");
         if (tai_fh == NULL) {

--- a/taf_view.c
+++ b/taf_view.c
@@ -301,7 +301,11 @@ int taf_view_main(int argc, char *argv[]) {
         }
         
         st_logInfo("Region: contig=%s start=%" PRIi64 " length=%" PRIi64 "\n", region_seq, region_start, region_length);
-        
+
+        if (inputFile == NULL) {
+            fprintf(stderr, "An input file must be specified with -i in order to perform region queries.\n");
+            return 1;
+        }
         char *tai_fn = tai_path(inputFile);        
         FILE *tai_fh = fopen(tai_fn, "r");
         

--- a/taffy/impl/tai.c
+++ b/taffy/impl/tai.c
@@ -6,6 +6,7 @@
 #include <time.h>
 
 char *tai_path(const char *taf_path) {
+    assert(taf_path != NULL);
     char *ret = (char*)st_calloc(strlen(taf_path) + 5, sizeof(char));
     sprintf(ret, "%s.tai", taf_path);
     return ret;    


### PR DESCRIPTION
`taffy view -r` needs an indexed input file to work.  but if the input is stdin, it just crashes when trying to determine the index filename (#62).  

This PR changes the crash into an error message (ditto `taffy coverage -s`).  

