### PR TITLE
Add mention of jbrowse support to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ See [using the Python API](https://github.com/ComparativeGenomicsToolkit/taffy/b
 
 See [the example notebook](https://github.com/ComparativeGenomicsToolkit/taffy/blob/main/examples/learning_phlyoP.ipynb) for a quick worked example of using the Python API for machine learning with PyTorch.
 
+### Third-party tools
+
+- JBrowse 2 with mafviewer plugin has TAF support https://github.com/cmdcolin/jbrowse-plugin-mafviewer
+
 ## Using the C Library
 
 There is also a simple C library for working with taf/maf files. See taf.h in the


### PR DESCRIPTION
Hi there,
I was inspired to experiment with the TAF format, and managed to get some basic support for bgzip'ed TAF+TAI into our JBrowse 2 "mafviewer" plugin

https://github.com/cmdcolin/jbrowse-plugin-mafviewer

Feel free to take or leave this PR, just thought i'd let ya know of third party ecosystem adoption around this format :)

if anyone from the team is attending PAG would be interested to chat also!